### PR TITLE
Update From.cs

### DIFF
--- a/src/ZendeskApi_v2/Models/Tickets/From.cs
+++ b/src/ZendeskApi_v2/Models/Tickets/From.cs
@@ -21,5 +21,11 @@ namespace ZendeskApi_v2.Models.Tickets
         /// </summary>
         [JsonProperty("phone")]
         public string Phone { get; set; }
+        
+        /// <summary>
+        /// Will be populated when Ticket is a follow-up ticket. See https://github.com/Speedygeek/ZendeskApi_v2/issues/427.
+        /// </summary>
+        [JsonProperty("ticket_id")]
+        public long? TicketId { get; set; }
     }
 }


### PR DESCRIPTION
When a Ticket was created as a follow-up to a closed ticket, the `via.source.from.ticket_id` property comes back from the API. Is this all that is needed to fill out the `TicketId` property here?