### PR TITLE
Allow pagination for GetMultipleTickets and GetMultipleTicketsAsync

### DIFF
--- a/src/ZendeskApi_v2/Requests/Tickets.cs
+++ b/src/ZendeskApi_v2/Requests/Tickets.cs
@@ -74,6 +74,10 @@ namespace ZendeskApi_v2.Requests
 
         GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
 
+        GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, int pageNumber, int itemsPerPage, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
+
+        GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, string sortBy, bool sortAscending, int pageNumber, int itemsPerPage, TicketS
+
         IndividualTicketResponse CreateTicket(Ticket ticket);
 
         JobStatusResponse CreateManyTickets(IEnumerable<Ticket> tickets);
@@ -176,6 +180,10 @@ namespace ZendeskApi_v2.Requests
         Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
 
         Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
+
+        Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
+
+        Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, string sortBy, bool sortAscending, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
 
         Task<IndividualTicketResponse> CreateTicketAsync(Ticket ticket);
 
@@ -392,6 +400,18 @@ namespace ZendeskApi_v2.Requests
         {
             var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/show_many.json?ids={ids.ToCsv()}", sideLoadOptions);
             return GenericGet<GroupTicketResponse>(resource);
+        }
+
+        public GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, int pageNumber, int itemsPerPage, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
+        {
+            var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/show_many.json?ids={ids.ToCsv()}", sideLoadOptions);
+            return GenericPagedGet<GroupTicketResponse>(resource, itemsPerPage, pageNumber);
+        }
+
+        public GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, string sortBy, bool sortAscending, int pageNumber, int itemsPerPage, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
+        {
+            var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/show_many.json?ids={ids.ToCsv()}", sideLoadOptions);
+            return GenericPagedSortedGet<GroupTicketResponse>(resource, itemsPerPage, pageNumber, sortBy, sortAscending);
         }
 
         public IndividualTicketResponse CreateTicket(Ticket ticket)
@@ -712,6 +732,18 @@ namespace ZendeskApi_v2.Requests
         public async Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
         {
             return await GenericGetAsync<GroupTicketResponse>(GetResourceStringWithSideLoadOptionsParam($"{_tickets}/show_many.json?ids={ids.ToCsv()}", sideLoadOptions));
+        }
+
+        public async Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
+        {
+            var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/show_many.json?ids={ids.ToCsv()}", sideLoadOptions);
+            return await GenericPagedGetAsync<GroupTicketResponse>(resource, perPage, page);
+        }
+
+        public async Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, string sortBy, bool sortAscending, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
+        {
+            var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/show_many.json?ids={ids.ToCsv()}", sideLoadOptions);
+            return await GenericPagedSortedGetAsync<GroupTicketResponse>(resource, perPage, page, sortBy, sortAscending);
         }
 
         public async Task<IndividualTicketResponse> CreateTicketAsync(Ticket ticket)

--- a/test/ZendeskApi_v2.Test/TicketTests.cs
+++ b/test/ZendeskApi_v2.Test/TicketTests.cs
@@ -320,6 +320,46 @@ namespace Tests
         }
 
         [Test]
+        public void CanGetMultipleTicketsPaged()
+        {
+            var ids = new List<long>() { Settings.SampleTicketId, Settings.SampleTicketId2 };
+            var tickets = api.Tickets.GetMultipleTickets(ids, 1, 2);
+
+            Assert.AreEqual(2, tickets.PageSize);
+            Assert.AreEqual(2, tickets.Tickets.Count);
+            Assert.Greater(tickets.Count, 0);
+
+            var nextPage = tickets.NextPage.GetQueryStringDict()
+                    .Where(x => x.Key == "page")
+                        .Select(x => x.Value)
+                        .FirstOrDefault();
+
+            Assert.NotNull(nextPage);
+
+            Assert.AreEqual("2", nextPage);
+        }
+
+        [Test]
+        public async Task CanGetMultipleTicketsAsyncPaged()
+        {
+            var ids = new List<long>() { Settings.SampleTicketId, Settings.SampleTicketId2 };
+            var tickets = await api.Tickets.GetMultipleTickets(ids, 1, 2);
+
+            Assert.AreEqual(2, tickets.PageSize);
+            Assert.AreEqual(2, tickets.Tickets.Count);
+            Assert.Greater(tickets.Count, 0);
+
+            var nextPage = tickets.NextPage.GetQueryStringDict()
+                    .Where(x => x.Key == "page")
+                        .Select(x => x.Value)
+                        .FirstOrDefault();
+
+            Assert.NotNull(nextPage);
+
+            Assert.AreEqual("2", nextPage);
+        }
+
+        [Test]
         public void BooleanCustomFieldValuesArePreservedOnUpdate()
         {
             var ticket = new Ticket()

--- a/test/ZendeskApi_v2.Test/TicketTests.cs
+++ b/test/ZendeskApi_v2.Test/TicketTests.cs
@@ -323,10 +323,10 @@ namespace Tests
         public void CanGetMultipleTicketsPaged()
         {
             var ids = new List<long>() { Settings.SampleTicketId, Settings.SampleTicketId2 };
-            var tickets = api.Tickets.GetMultipleTickets(ids, 1, 2);
+            var tickets = api.Tickets.GetMultipleTickets(ids, 1, 1);
 
-            Assert.AreEqual(2, tickets.PageSize);
-            Assert.AreEqual(2, tickets.Tickets.Count);
+            Assert.AreEqual(1, tickets.PageSize);
+            Assert.AreEqual(1, tickets.Tickets.Count);
             Assert.Greater(tickets.Count, 0);
 
             var nextPage = tickets.NextPage.GetQueryStringDict()
@@ -343,10 +343,10 @@ namespace Tests
         public async Task CanGetMultipleTicketsAsyncPaged()
         {
             var ids = new List<long>() { Settings.SampleTicketId, Settings.SampleTicketId2 };
-            var tickets = await api.Tickets.GetMultipleTickets(ids, 1, 2);
+            var tickets = await api.Tickets.GetMultipleTickets(ids, 1, 1);
 
-            Assert.AreEqual(2, tickets.PageSize);
-            Assert.AreEqual(2, tickets.Tickets.Count);
+            Assert.AreEqual(1, tickets.PageSize);
+            Assert.AreEqual(1, tickets.Tickets.Count);
             Assert.Greater(tickets.Count, 0);
 
             var nextPage = tickets.NextPage.GetQueryStringDict()


### PR DESCRIPTION
Previously unable to page through results when using the `GetMultipleTickets` and `GetMultipleTicketsAsync` methods. I created overrides to enable pagination for these methods. Let me know if I need to fix anything.