### PR TITLE
Corrected support for CurrentQueueActrivity using a Response pattern

### DIFF
--- a/src/ZendeskApi_v2/Models/Voice/CurrentQueueActivityResponse.cs
+++ b/src/ZendeskApi_v2/Models/Voice/CurrentQueueActivityResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.Voice
+{
+    public class CurrentQueueActivityResponse
+    {
+        [JsonProperty("current_queue_activity")]
+        public CurrentQueueActivity CurrentQueueActivity { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Requests/Voice.cs
+++ b/src/ZendeskApi_v2/Requests/Voice.cs
@@ -13,7 +13,7 @@ namespace ZendeskApi_v2.Requests
         bool OpenUserProfileInAgentBrowser(long agentId, long userId);
         bool OpenTicketInAgentBrowser(long agentId, long ticketId);
         GroupAgentActivityResponse GetVoiceAgentActivity();
-        CurrentQueueActivity GetCurrentQueueActivity();
+        CurrentQueueActivityResponse GetCurrentQueueActivity();
 
 #endif
 
@@ -21,7 +21,7 @@ namespace ZendeskApi_v2.Requests
         Task<bool> OpenUserProfileInAgentBrowserAsync(long agentId, long userId);
         Task<bool> OpenTicketInAgentBrowserAsync(long agentId, long ticketId);
         Task<GroupAgentActivityResponse> GetVoiceAgentActivityAsync();
-        Task<CurrentQueueActivity> GetCurrentQueueActivityAsync();
+        Task<CurrentQueueActivityResponse> GetCurrentQueueActivityAsync();
 #endif
     }
 
@@ -56,9 +56,9 @@ namespace ZendeskApi_v2.Requests
             return GenericGet<GroupAgentActivityResponse>(agentsActivity + ".json");
         }
 
-        public CurrentQueueActivity GetCurrentQueueActivity()
+        public CurrentQueueActivityResponse GetCurrentQueueActivity()
         {
-            return GenericGet<CurrentQueueActivity>(currentQueueActivity + ".json");
+            return GenericGet<CurrentQueueActivityResponse>(currentQueueActivity + ".json");
         }
 
 #endif
@@ -79,9 +79,9 @@ namespace ZendeskApi_v2.Requests
             return await GenericGetAsync<GroupAgentActivityResponse>(agentsActivity + ".json");
         }
 
-        public async Task<CurrentQueueActivity> GetCurrentQueueActivityAsync()
+        public async Task<CurrentQueueActivityResponse> GetCurrentQueueActivityAsync()
         {
-            return await GenericGetAsync<CurrentQueueActivity>(currentQueueActivity + ".json");
+            return await GenericGetAsync<CurrentQueueActivityResponse>(currentQueueActivity + ".json");
         }
 #endif
     }

--- a/test/ZendeskApi_v2.Test/Models/Voice/FromTests.cs
+++ b/test/ZendeskApi_v2.Test/Models/Voice/FromTests.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+using ZendeskApi_v2.Models.Voice;
+
+namespace Tests.Models.Voice
+{
+    [TestFixture]
+    public class FromTests
+    {
+        private const string AllFieldsJson = "{\"current_queue_activity\":{\"agents_online\":3,\"average_wait_time\":142,\"calls_waiting\":13,\"longest_wait_time\":387,\"callbacks_waiting\":7,\"embeddable_callbacks_waiting\":0}}";
+
+        [Test]
+        public void DeserializeAllFieldsTest()
+        {
+            var from = JsonConvert.DeserializeObject<CurrentQueueActivityResponse>(AllFieldsJson);
+
+            Assert.NotNull(from);
+            Assert.AreEqual(3, from.CurrentQueueActivity.AgentsOnline);
+            Assert.AreEqual(13, from.CurrentQueueActivity.CallsWaiting);
+            Assert.AreEqual(7, from.CurrentQueueActivity.CallbacksWaiting);
+            Assert.AreEqual(142, from.CurrentQueueActivity.AverageWaitTime);
+            Assert.AreEqual(387, from.CurrentQueueActivity.LongestWaitTime);
+        }
+    }
+}

--- a/test/ZendeskApi_v2.Test/Models/Voice/FromTests.cs
+++ b/test/ZendeskApi_v2.Test/Models/Voice/FromTests.cs
@@ -15,11 +15,11 @@ namespace Tests.Models.Voice
             var from = JsonConvert.DeserializeObject<CurrentQueueActivityResponse>(AllFieldsJson);
 
             Assert.NotNull(from);
-            Assert.AreEqual(3, from.CurrentQueueActivity.AgentsOnline);
-            Assert.AreEqual(13, from.CurrentQueueActivity.CallsWaiting);
-            Assert.AreEqual(7, from.CurrentQueueActivity.CallbacksWaiting);
-            Assert.AreEqual(142, from.CurrentQueueActivity.AverageWaitTime);
-            Assert.AreEqual(387, from.CurrentQueueActivity.LongestWaitTime);
+            Assert.That(from.CurrentQueueActivity.AgentsOnline, Is.EqualTo(3));
+            Assert.That(from.CurrentQueueActivity.CallsWaiting, Is.EqualTo(13));
+            Assert.That(from.CurrentQueueActivity.CallbacksWaiting, Is.EqualTo(7));
+            Assert.That(from.CurrentQueueActivity.AverageWaitTime, Is.EqualTo(142));
+            Assert.That(from.CurrentQueueActivity.LongestWaitTime, Is.EqualTo(387));
         }
     }
 }


### PR DESCRIPTION
Fix for #445 
Added a fix for CurrentQueueActivity for Zendesk Voice/Talk API. Prev. it always returned 0 for all fields, this PR changes the api ZendeskApi.Voice.GetCurrentQueueActivity to return a CurrentQueueActivityResponse instead of a CurrentQueueActivity (which had all fields set to 0). Also added a unit test.