### PR TITLE
Added sort direction to GetTicketComments

### DIFF
--- a/src/ZendeskApi_v2/Requests/Tickets.cs
+++ b/src/ZendeskApi_v2/Requests/Tickets.cs
@@ -72,6 +72,8 @@ namespace ZendeskApi_v2.Requests
 
         GroupCommentResponse GetTicketComments(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
 
+        GroupCommentResponse GetTicketComments(long ticketId, bool sortAscending, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
+
         GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
 
         IndividualTicketResponse CreateTicket(Ticket ticket);
@@ -388,6 +390,12 @@ namespace ZendeskApi_v2.Requests
         {
             var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/{ticketId}/comments.json", sideLoadOptions);
             return GenericPagedGet<GroupCommentResponse>(resource, perPage, page);
+        }
+
+        public GroupCommentResponse GetTicketComments(long ticketId, bool sortAscending, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
+        {
+            var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/{ticketId}/comments.json", sideLoadOptions);
+            return GenericPagedSortedGet<GroupCommentResponse>(resource, perPage, page, sortAscending: sortAscending);
         }
 
         public GroupTicketResponse GetMultipleTickets(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)

--- a/src/ZendeskApi_v2/Requests/Tickets.cs
+++ b/src/ZendeskApi_v2/Requests/Tickets.cs
@@ -175,6 +175,8 @@ namespace ZendeskApi_v2.Requests
 
         Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
 
+        Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, bool sortAscending, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
+
         Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None);
 
         Task<IndividualTicketResponse> CreateTicketAsync(Ticket ticket);
@@ -718,6 +720,12 @@ namespace ZendeskApi_v2.Requests
         {
             var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/{ticketId}/comments.json", sideLoadOptions);
             return await GenericPagedGetAsync<GroupCommentResponse>(resource, perPage, page);
+        }
+
+        public async Task<GroupCommentResponse> GetTicketCommentsAsync(long ticketId, bool sortAscending, int? perPage = null, int? page = null, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)
+        {
+            var resource = GetResourceStringWithSideLoadOptionsParam($"{_tickets}/{ticketId}/comments.json", sideLoadOptions);
+            return await GenericPagedSortedGetAsync<GroupCommentResponse>(resource, perPage, page, sortAscending: sortAscending);
         }
 
         public async Task<GroupTicketResponse> GetMultipleTicketsAsync(IEnumerable<long> ids, TicketSideLoadOptionsEnum sideLoadOptions = TicketSideLoadOptionsEnum.None)

--- a/test/ZendeskApi_v2.Test/TicketTests.cs
+++ b/test/ZendeskApi_v2.Test/TicketTests.cs
@@ -489,6 +489,18 @@ namespace Tests
         }
 
         [Test]
+        public void CanGetTicketCommentsPagedAndSorted()
+        {
+            const int perPage = 1;
+            const int page = 1;
+            var commentsRes = api.Tickets.GetTicketComments(2, perPage, page);
+            var commentsRes2 = api.Tickets.GetTicketComments(2, false, perPage, page);
+
+            Assert.AreEqual(new DateTimeOffset(2012, 10, 30, 13, 35, 11, TimeSpan.Zero), commentsRes.Comments[0].CreatedAt);
+            Assert.AreEqual(new DateTimeOffset(2014, 01, 24, 03, 29, 30, TimeSpan.Zero), commentsRes2.Comments[0].CreatedAt);
+        }
+
+        [Test]
         public void CanCreateTicketWithRequester()
         {
             var ticket = new Ticket()

--- a/test/ZendeskApi_v2.Test/TicketTests.cs
+++ b/test/ZendeskApi_v2.Test/TicketTests.cs
@@ -1185,10 +1185,13 @@ namespace Tests
         {
             // see https://github.com/mozts2005/ZendeskApi_v2/issues/254
 
+            var initCommentBody = "HELP";
+            var secondCommentBody = "New comment";
+
             var ticket = new Ticket()
             {
                 Subject = "my printer is on fire",
-                Comment = new Comment() { Body = "HELP" },
+                Comment = new Comment() { Body = initCommentBody },
                 Priority = TicketPriorities.Urgent
             };
 
@@ -1206,12 +1209,15 @@ namespace Tests
 
             Assert.That(newTicket.Via.Channel, Is.EqualTo("api"));
 
-            var comment = new Comment { Body = "New comment", Public = true };
+            var comment = new Comment { Body = secondCommentBody, Public = true };
 
             var resp2 = await api.Tickets.UpdateTicketAsync(newTicket, comment);
             var resp3 = await api.Tickets.GetTicketCommentsAsync(newTicket.Id.Value);
+            var resp4 = await api.Tickets.GetTicketCommentsAsync(newTicket.Id.Value, false);
 
             Assert.That(resp3.Comments.Any(c => c.Via?.Channel != "api"), Is.False);
+            Assert.That(resp3.Comments[0].Body, Is.EqualTo(initCommentBody));
+            Assert.That(resp4.Comments[0].Body, Is.EqualTo(secondCommentBody));
 
             // clean up
             await api.Tickets.DeleteAsync(newTicket.Id.Value);


### PR DESCRIPTION
Zendesk supports sorting comments:
![TicketCommentsSortOrder](https://user-images.githubusercontent.com/17003924/71177343-16a5d300-226c-11ea-9512-0c9391bd6ab7.PNG)
