### PR TITLE
Added 'url_target_v2' to Target Json Converter to return HttpTarget

### DIFF
--- a/src/ZendeskApi_v2/Serialization/TargetJsonConverter.cs
+++ b/src/ZendeskApi_v2/Serialization/TargetJsonConverter.cs
@@ -33,6 +33,8 @@ namespace ZendeskApi_v2.Serialization
                     return new URLTarget();
                 case "http_target":
                     return new HTTPTarget();
+                case "url_target_v2":
+                    return new HTTPTarget();
                 default:
                     return null;
             }

--- a/test/ZendeskApi_v2.Test/TargetTests.cs
+++ b/test/ZendeskApi_v2.Test/TargetTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System.Linq;
+using System.Net;
 using ZendeskApi_v2;
 using ZendeskApi_v2.Models.Targets;
 
@@ -22,6 +23,39 @@ namespace Tests
                     api.Targets.DeleteTarget(target.Id.Value);
                 }
             }
+        }
+
+        [Test]
+        public void CanCreateUpdateAndDeleteHttpTargets()
+        {
+            var target = new HTTPTarget()
+            {
+                Title = "Test Email Target",
+                Active = false, 
+                TargetUrl= "https://test.com",
+                ContentType = "application/json",
+                Method = "post",
+                Username = "TestUser",
+                Password = "TestPass"
+            };
+
+            var targetResult = (HTTPTarget)api.Targets.CreateTarget(target).Target;
+            Assert.IsNotNull(targetResult);
+            Assert.IsInstanceOf<HTTPTarget>(targetResult);
+            Assert.IsFalse(targetResult.Active);
+            Assert.AreEqual("https://test.com", targetResult.TargetUrl);
+            Assert.AreEqual("http_target", targetResult.Type);
+            Assert.AreEqual("application/json", targetResult.ContentType);
+            Assert.AreEqual("post", targetResult.Method);
+            Assert.AreEqual("TestUser", targetResult.Username);
+            Assert.IsNull(targetResult.Password);
+
+            targetResult.Active = true;
+
+            var update = (HTTPTarget)api.Targets.UpdateTarget(targetResult).Target;
+            Assert.AreEqual(targetResult.Active, update.Active);
+
+            Assert.True(api.Targets.DeleteTarget(update.Id.Value));
         }
 
         [Test]


### PR DESCRIPTION
Bug(TargetDeserialization): Adding 'url_target_v2' as type for HttpTarget

Zendesk returns 'url_target_v2' as the type of created http_targets for some reason meaning an ArgumentNullException was thrown when creating a target.

