### PR TITLE
Paginate GetSections call

### DIFF
--- a/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
@@ -11,6 +11,7 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     {
 #if SYNC
         GroupCategoryResponse GetCategories();
+        GroupCategoryResponse GetCategories(int perPage, int page);
         IndividualCategoryResponse GetCategoryById(long id);
         IndividualCategoryResponse CreateCategory(Category category);
         IndividualCategoryResponse UpdateCategory(Category category);
@@ -46,7 +47,12 @@ namespace ZendeskApi_v2.Requests.HelpCenter
             return GenericGet<GroupCategoryResponse>($"{GeneralCategoriesPath}.json");
         }
 
-        public IndividualCategoryResponse GetCategoryById(long id) 
+        public GroupCategoryResponse GetCategories(int perPage, int page)
+        {
+            return GenericPagedGet<GroupCategoryResponse>($"{GeneralCategoriesPath}.json", perPage, page);
+        }
+
+        public IndividualCategoryResponse GetCategoryById(long id)
         {
             return GenericGet<IndividualCategoryResponse>($"{GeneralCategoriesPath}/{id}.json");
         }

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
@@ -20,6 +20,7 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
 #if ASYNC
         Task<GroupCategoryResponse> GetCategoriesAsync();
+        Task<GroupCategoryResponse> GetCategoriesAsync(int perPage, int page);
         Task<IndividualCategoryResponse> GetCategoryByIdAsync(long id);
         Task<IndividualCategoryResponse> CreateCategoryAsync(Category category);
         Task<IndividualCategoryResponse> UpdateCategoryAsync(Category category);
@@ -85,6 +86,11 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         public async Task<GroupCategoryResponse> GetCategoriesAsync()
         {
             return await GenericGetAsync<GroupCategoryResponse>($"{GeneralCategoriesPath}.json");
+        }
+
+        public async Task<GroupCategoryResponse> GetCategoriesAsync(int perPage, int page)
+        {
+            return await GenericPagedGetAsync<GroupCategoryResponse>($"{GeneralCategoriesPath}.json", perPage, page);
         }
 
         public async Task<IndividualCategoryResponse> GetCategoryByIdAsync(long id)

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
@@ -10,7 +10,7 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     public interface ISections : ICore
     {
 #if SYNC
-        GroupSectionResponse GetSections();
+        GroupSectionResponse GetSections(int? perPage = null, int? page = null);
         GroupSectionResponse GetSectionsByCategoryId(long categoryId);
         IndividualSectionResponse GetSectionById(long id);
         IndividualSectionResponse CreateSection(Section section);
@@ -49,9 +49,9 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         }
 
 #if SYNC
-        public GroupSectionResponse GetSections()
+        public GroupSectionResponse GetSections(int? perPage = null, int? page = null)
         {
-            return GenericGet<GroupSectionResponse>($"{_generalSectionsPath}.json?include=access_policies");
+            return GenericPagedGet<GroupSectionResponse>($"{_generalSectionsPath}.json?include=access_policies", perPage, page);
         }
         public GroupSectionResponse GetSectionsByCategoryId(long categoryId)
         {

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
@@ -25,6 +25,7 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
 #if ASYNC
         Task<GroupSectionResponse> GetSectionsAsync();
+        Task<GroupSectionResponse> GetSectionsAsync(int perPage, int page);
         Task<GroupSectionResponse> GetSectionsByCategoryIdAsync(long categoryId);
         Task<IndividualSectionResponse> GetSectionByIdAsync(long id);
         Task<IndividualSectionResponse> CreateSectionAsync(Section section);
@@ -110,6 +111,11 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         public async Task<GroupSectionResponse> GetSectionsAsync()
         {
             return await GenericGetAsync<GroupSectionResponse>($"{_generalSectionsPath}.json?include=access_policies");
+        }
+
+        public async Task<GroupSectionResponse> GetSectionsAsync(int perPage, int page)
+        {
+            return await GenericPagedGetAsync<GroupSectionResponse>($"{_generalSectionsPath}.json?include=access_policies", perPage, page);
         }
 
         public async Task<GroupSectionResponse> GetSectionsByCategoryIdAsync(long categoryId)

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
@@ -10,7 +10,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     public interface ISections : ICore
     {
 #if SYNC
-        GroupSectionResponse GetSections(int? perPage = null, int? page = null);
+        GroupSectionResponse GetSections();
+        GroupSectionResponse GetSections(int perPage, int page);
         GroupSectionResponse GetSectionsByCategoryId(long categoryId);
         IndividualSectionResponse GetSectionById(long id);
         IndividualSectionResponse CreateSection(Section section);
@@ -49,10 +50,16 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         }
 
 #if SYNC
-        public GroupSectionResponse GetSections(int? perPage = null, int? page = null)
+        public GroupSectionResponse GetSections()
+        {
+            return GenericGet<GroupSectionResponse>($"{_generalSectionsPath}.json?include=access_policies");
+        }
+
+        public GroupSectionResponse GetSections(int perPage, int page)
         {
             return GenericPagedGet<GroupSectionResponse>($"{_generalSectionsPath}.json?include=access_policies", perPage, page);
         }
+
         public GroupSectionResponse GetSectionsByCategoryId(long categoryId)
         {
             return GenericGet<GroupSectionResponse>(GetSectionPathWithCategory(categoryId));

--- a/test/ZendeskApi_v2.Test/HelpCenter/CategoryTests.cs
+++ b/test/ZendeskApi_v2.Test/HelpCenter/CategoryTests.cs
@@ -66,23 +66,65 @@ namespace Tests.HelpCenter
             const int count = 2;
             var categories = api.HelpCenter.Categories.GetCategories(count, 1);
 
-            Assert.AreEqual(count, categories.Categories.Count);  // 2
-            Assert.AreNotEqual(categories.Count, categories.Categories.Count);   // 2 != total count of categories (assumption)
+            Assert.That(count, Is.EqualTo(categories.Categories.Count));  // 2
+            Assert.That(categories.Count, !Is.EqualTo(categories.Categories.Count));   // 2 != total count of categories (assumption)
 
             const int page = 2;
             var secondPage = api.HelpCenter.Categories.GetCategories(count, page);
 
-            Assert.AreEqual(count, secondPage.Categories.Count);
+            Assert.That(count, Is.EqualTo(secondPage.Categories.Count));
 
             var nextPage = secondPage.NextPage.GetQueryStringDict()
                 .Where(x => x.Key == "page")
                 .Select(x => x.Value)
                 .FirstOrDefault();
 
-            Assert.NotNull(nextPage);
-            Assert.AreEqual(nextPage, (page + 1).ToString());
-            Assert.True(api.HelpCenter.Categories.DeleteCategory(category1.Category.Id.Value));
-            Assert.True(api.HelpCenter.Categories.DeleteCategory(category2.Category.Id.Value));
+            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
+            Assert.That(api.HelpCenter.Categories.DeleteCategory(category1.Category.Id.Value), Is.True);
+            Assert.That(api.HelpCenter.Categories.DeleteCategory(category2.Category.Id.Value), Is.True);
+        }
+
+        [Test]
+        public void CanGetCategoriesPagedAsync()
+        {
+            var category1 = api.HelpCenter.Categories.CreateCategory(new Category {
+                Name = "My Test category 1",
+                Position = 0,
+                Description = "First category"
+            });
+
+            var category2 = api.HelpCenter.Categories.CreateCategory(new Category {
+                Name = "My Test category 2",
+                Position = 0,
+                Description = "Second category"
+            });
+
+            const int count = 2;
+            var categoriesAsync = api.HelpCenter.Categories.GetCategoriesAsync(count, 1).Result;
+
+            Assert.That(categoriesAsync.Count > 0);
+
+            var categoryById1 = api.HelpCenter.Categories.GetCategoryById(categoriesAsync.Categories[0].Id.Value);
+
+            Assert.That(categoryById1.Category.Id, Is.EqualTo(categoriesAsync.Categories[0].Id.Value));
+
+            const int page = 2;
+            var secondPage = api.HelpCenter.Categories.GetCategoriesAsync(count, page).Result;
+            var categoryById2 = api.HelpCenter.Categories.GetCategoryById(secondPage.Categories[0].Id.Value);
+
+            Assert.That(count, Is.EqualTo(secondPage.Categories.Count));
+            Assert.That(categoryById2.Category.Id, Is.EqualTo(secondPage.Categories[0].Id.Value));
+
+            var nextPage = secondPage.NextPage.GetQueryStringDict()
+                .Where(x => x.Key == "page")
+                .Select(x => x.Value)
+                .FirstOrDefault();
+
+            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
+            Assert.That(api.HelpCenter.Categories.DeleteCategory(category1.Category.Id.Value), Is.True);
+            Assert.That(api.HelpCenter.Categories.DeleteCategory(category2.Category.Id.Value), Is.True);
         }
 
         [Test]

--- a/test/ZendeskApi_v2.Test/HelpCenter/CategoryTests.cs
+++ b/test/ZendeskApi_v2.Test/HelpCenter/CategoryTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using ZendeskApi_v2;
+using ZendeskApi_v2.Extensions;
 using ZendeskApi_v2.Models.HelpCenter.Categories;
 
 namespace Tests.HelpCenter
@@ -15,11 +17,11 @@ namespace Tests.HelpCenter
         [OneTimeSetUp]
         public async Task Setup()
         {
-            var categotriesResponse = await api.HelpCenter.Categories.GetCategoriesAsync();
+            var categoriesResponse = await api.HelpCenter.Categories.GetCategoriesAsync();
 
             do
             {
-                foreach (var category in categotriesResponse.Categories)
+                foreach (var category in categoriesResponse.Categories)
                 {
                     if (category.Name == "My Test category")
                     {
@@ -27,12 +29,12 @@ namespace Tests.HelpCenter
                     }
                 }
 
-                if (!string.IsNullOrWhiteSpace(categotriesResponse.NextPage))
+                if (!string.IsNullOrWhiteSpace(categoriesResponse.NextPage))
                 {
-                    categotriesResponse = await api.HelpCenter.Articles.GetByPageUrlAsync<GroupCategoryResponse>(categotriesResponse.NextPage, 100);
+                    categoriesResponse = await api.HelpCenter.Articles.GetByPageUrlAsync<GroupCategoryResponse>(categoriesResponse.NextPage, 100);
                 }
 
-            } while (!string.IsNullOrWhiteSpace(categotriesResponse.NextPage));
+            } while (!string.IsNullOrWhiteSpace(categoriesResponse.NextPage));
         }
 
 
@@ -44,6 +46,43 @@ namespace Tests.HelpCenter
 
             var res1 = api.HelpCenter.Categories.GetCategoryById(res.Categories[0].Id.Value);
             Assert.AreEqual(res1.Category.Id, res.Categories[0].Id.Value);
+        }
+
+        [Test]
+        public void CanGetCategoriesPaged()
+        {
+           var category1 = api.HelpCenter.Categories.CreateCategory(new Category {
+                Name = "My Test category 1",
+                Position = 0,
+                Description = "First category"
+            });
+
+            var category2 = api.HelpCenter.Categories.CreateCategory(new Category {
+                Name = "My Test category 2",
+                Position = 0,
+                Description = "Second category"
+            });
+
+            const int count = 2;
+            var categories = api.HelpCenter.Categories.GetCategories(count, 1);
+
+            Assert.AreEqual(count, categories.Categories.Count);  // 2
+            Assert.AreNotEqual(categories.Count, categories.Categories.Count);   // 2 != total count of categories (assumption)
+
+            const int page = 2;
+            var secondPage = api.HelpCenter.Categories.GetCategories(count, page);
+
+            Assert.AreEqual(count, secondPage.Categories.Count);
+
+            var nextPage = secondPage.NextPage.GetQueryStringDict()
+                .Where(x => x.Key == "page")
+                .Select(x => x.Value)
+                .FirstOrDefault();
+
+            Assert.NotNull(nextPage);
+            Assert.AreEqual(nextPage, (page + 1).ToString());
+            Assert.True(api.HelpCenter.Categories.DeleteCategory(category1.Category.Id.Value));
+            Assert.True(api.HelpCenter.Categories.DeleteCategory(category2.Category.Id.Value));
         }
 
         [Test]

--- a/test/ZendeskApi_v2.Test/HelpCenter/CategoryTests.cs
+++ b/test/ZendeskApi_v2.Test/HelpCenter/CategoryTests.cs
@@ -67,7 +67,7 @@ namespace Tests.HelpCenter
             var categories = api.HelpCenter.Categories.GetCategories(count, 1);
 
             Assert.That(count, Is.EqualTo(categories.Categories.Count));  // 2
-            Assert.That(categories.Count, !Is.EqualTo(categories.Categories.Count));   // 2 != total count of categories (assumption)
+            Assert.That(categories.Count, Is.Not.EqualTo(categories.Categories.Count));   // 2 != total count of categories (assumption)
 
             const int page = 2;
             var secondPage = api.HelpCenter.Categories.GetCategories(count, page);
@@ -79,7 +79,7 @@ namespace Tests.HelpCenter
                 .Select(x => x.Value)
                 .FirstOrDefault();
 
-            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.Not.Null);
             Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
             Assert.That(api.HelpCenter.Categories.DeleteCategory(category1.Category.Id.Value), Is.True);
             Assert.That(api.HelpCenter.Categories.DeleteCategory(category2.Category.Id.Value), Is.True);
@@ -103,7 +103,7 @@ namespace Tests.HelpCenter
             const int count = 2;
             var categoriesAsync = api.HelpCenter.Categories.GetCategoriesAsync(count, 1).Result;
 
-            Assert.That(categoriesAsync.Count > 0);
+            Assert.That(categoriesAsync.Count,  Is.GreaterThan(0));
 
             var categoryById1 = api.HelpCenter.Categories.GetCategoryById(categoriesAsync.Categories[0].Id.Value);
 
@@ -121,7 +121,7 @@ namespace Tests.HelpCenter
                 .Select(x => x.Value)
                 .FirstOrDefault();
 
-            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.Not.Null);
             Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
             Assert.That(api.HelpCenter.Categories.DeleteCategory(category1.Category.Id.Value), Is.True);
             Assert.That(api.HelpCenter.Categories.DeleteCategory(category2.Category.Id.Value), Is.True);

--- a/test/ZendeskApi_v2.Test/HelpCenter/SectionTests.cs
+++ b/test/ZendeskApi_v2.Test/HelpCenter/SectionTests.cs
@@ -68,7 +68,7 @@ namespace Tests.HelpCenter
             var sections = api.HelpCenter.Sections.GetSections(count, 1);
 
             Assert.That(count, Is.EqualTo(sections.Sections.Count));  // 2
-            Assert.That(sections.Count, !Is.EqualTo(sections.Sections.Count));   // 2 != total count of sections (assumption)
+            Assert.That(sections.Count, Is.Not.EqualTo(sections.Sections.Count));   // 2 != total count of sections (assumption)
 
             const int page = 2;
             var secondPage = api.HelpCenter.Sections.GetSections(count, page);
@@ -80,7 +80,7 @@ namespace Tests.HelpCenter
                 .Select(x => x.Value)
                 .FirstOrDefault();
 
-            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.Not.Null);
             Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
             Assert.That(api.HelpCenter.Sections.DeleteSection(section1.Section.Id.Value), Is.True);
             Assert.That(api.HelpCenter.Sections.DeleteSection(section2.Section.Id.Value), Is.True);
@@ -107,7 +107,7 @@ namespace Tests.HelpCenter
             const int count = 2;
             var sectionsAsync = api.HelpCenter.Sections.GetSectionsAsync(count, 1).Result;
 
-            Assert.That(sectionsAsync.Count > 0);
+            Assert.That(sectionsAsync.Count, Is.GreaterThan(0));
 
             var sectionById1 = api.HelpCenter.Sections.GetSectionById(sectionsAsync.Sections[0].Id.Value);
 
@@ -125,7 +125,7 @@ namespace Tests.HelpCenter
                 .Select(x => x.Value)
                 .FirstOrDefault();
 
-            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.Not.Null);
             Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
             Assert.That(api.HelpCenter.Sections.DeleteSection(section1.Section.Id.Value), Is.True);
             Assert.That(api.HelpCenter.Sections.DeleteSection(section2.Section.Id.Value), Is.True);

--- a/test/ZendeskApi_v2.Test/HelpCenter/SectionTests.cs
+++ b/test/ZendeskApi_v2.Test/HelpCenter/SectionTests.cs
@@ -67,21 +67,66 @@ namespace Tests.HelpCenter
             const int count = 2;
             var sections = api.HelpCenter.Sections.GetSections(count, 1);
 
-            Assert.AreEqual(count, sections.Sections.Count);  // 2
-            Assert.AreNotEqual(sections.Count, sections.Sections.Count);   // 2 != total count of sections (assumption)
+            Assert.That(count, Is.EqualTo(sections.Sections.Count));  // 2
+            Assert.That(sections.Count, !Is.EqualTo(sections.Sections.Count));   // 2 != total count of sections (assumption)
 
             const int page = 2;
             var secondPage = api.HelpCenter.Sections.GetSections(count, page);
 
-            Assert.AreEqual(count, secondPage.Sections.Count);
+            Assert.That(count, Is.EqualTo(secondPage.Sections.Count));
 
             var nextPage = secondPage.NextPage.GetQueryStringDict()
                 .Where(x => x.Key == "page")
                 .Select(x => x.Value)
                 .FirstOrDefault();
 
-            Assert.NotNull(nextPage);
-            Assert.AreEqual(nextPage, (page + 1).ToString());
+            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
+            Assert.That(api.HelpCenter.Sections.DeleteSection(section1.Section.Id.Value), Is.True);
+            Assert.That(api.HelpCenter.Sections.DeleteSection(section2.Section.Id.Value), Is.True);
+        }
+
+        [Test]
+        public void CanGetSectionsPagedAsync()
+        {
+            //https://csharpapi.zendesk.com/hc/en-us/categories/200382245-Category-1
+            long category_id = 200382245;
+
+            var section1 = api.HelpCenter.Sections.CreateSection(new Section {
+                Name = "My Test section 1",
+                Position = 0,
+                CategoryId = category_id
+            });
+
+            var section2 = api.HelpCenter.Sections.CreateSection(new Section {
+                Name = "My Test section 2",
+                Position = 0,
+                CategoryId = category_id
+            });
+
+            const int count = 2;
+            var sectionsAsync = api.HelpCenter.Sections.GetSectionsAsync(count, 1).Result;
+
+            Assert.That(sectionsAsync.Count > 0);
+
+            var sectionById1 = api.HelpCenter.Sections.GetSectionById(sectionsAsync.Sections[0].Id.Value);
+
+            Assert.That(sectionById1.Section.Id, Is.EqualTo(sectionsAsync.Sections[0].Id.Value));
+
+            const int page = 2;
+            var secondPage = api.HelpCenter.Sections.GetSectionsAsync(count, page).Result;
+            var sectionById2 = api.HelpCenter.Sections.GetSectionById(secondPage.Sections[0].Id.Value);
+
+            Assert.That(count, Is.EqualTo(secondPage.Sections.Count));
+            Assert.That(sectionById2.Section.Id, Is.EqualTo(secondPage.Sections[0].Id.Value));
+
+            var nextPage = secondPage.NextPage.GetQueryStringDict()
+                .Where(x => x.Key == "page")
+                .Select(x => x.Value)
+                .FirstOrDefault();
+
+            Assert.That(nextPage != null);
+            Assert.That(nextPage, Is.EqualTo((page + 1).ToString()));
             Assert.That(api.HelpCenter.Sections.DeleteSection(section1.Section.Id.Value), Is.True);
             Assert.That(api.HelpCenter.Sections.DeleteSection(section2.Section.Id.Value), Is.True);
         }

--- a/test/ZendeskApi_v2.Test/HelpCenter/SectionTests.cs
+++ b/test/ZendeskApi_v2.Test/HelpCenter/SectionTests.cs
@@ -65,7 +65,7 @@ namespace Tests.HelpCenter
             });
 
             const int count = 2;
-            var sections = api.HelpCenter.Sections.GetSections(count);
+            var sections = api.HelpCenter.Sections.GetSections(count, 1);
 
             Assert.AreEqual(count, sections.Sections.Count);  // 2
             Assert.AreNotEqual(sections.Count, sections.Sections.Count);   // 2 != total count of sections (assumption)
@@ -82,8 +82,8 @@ namespace Tests.HelpCenter
 
             Assert.NotNull(nextPage);
             Assert.AreEqual(nextPage, (page + 1).ToString());
-            api.HelpCenter.Sections.DeleteSection(section1.Section.Id.Value);
-            api.HelpCenter.Sections.DeleteSection(section2.Section.Id.Value);
+            Assert.That(api.HelpCenter.Sections.DeleteSection(section1.Section.Id.Value), Is.True);
+            Assert.That(api.HelpCenter.Sections.DeleteSection(section2.Section.Id.Value), Is.True);
         }
 
         [Test]


### PR DESCRIPTION
The call to retrieve sections is paginated, this ensures that the results won't cut off after 30 entries. I also added a unit test based on the one done for the paginated Tickets call.