### PR TITLE
Paginated group memberships

### DIFF
--- a/src/ZendeskApi_v2/Requests/Groups.cs
+++ b/src/ZendeskApi_v2/Requests/Groups.cs
@@ -5,69 +5,69 @@ using ZendeskApi_v2.Models.Groups;
 
 namespace ZendeskApi_v2.Requests
 {
-	public interface IGroups : ICore
-	{
+    public interface IGroups : ICore
+    {
 #if SYNC
-		MultipleGroupResponse GetGroups(int? perPage = null, int? page = null);
-		MultipleGroupResponse GetAssignableGroups();
-		IndividualGroupResponse GetGroupById(long id);
-		IndividualGroupResponse CreateGroup(string groupName);
-		IndividualGroupResponse UpdateGroup(Group group);
-		bool DeleteGroup(long id);
-		MultipleGroupMembershipResponse GetGroupMemberships();
-		MultipleGroupMembershipResponse GetGroupMembershipsByUser(long userId);
-		MultipleGroupMembershipResponse GetGroupMembershipsByUser(long userId, int perPage, int page);
-		MultipleGroupMembershipResponse GetGroupMembershipsByGroup(long groupId);
+        MultipleGroupResponse GetGroups(int? perPage = null, int? page = null);
+        MultipleGroupResponse GetAssignableGroups();
+        IndividualGroupResponse GetGroupById(long id);
+        IndividualGroupResponse CreateGroup(string groupName);
+        IndividualGroupResponse UpdateGroup(Group group);
+        bool DeleteGroup(long id);
+        MultipleGroupMembershipResponse GetGroupMemberships();
+        MultipleGroupMembershipResponse GetGroupMembershipsByUser(long userId);
+        MultipleGroupMembershipResponse GetGroupMembershipsByUser(long userId, int perPage, int page);
+        MultipleGroupMembershipResponse GetGroupMembershipsByGroup(long groupId);
         MultipleGroupMembershipResponse GetGroupMembershipsByGroup(long groupId, int perPage, int page);
         MultipleGroupMembershipResponse GetAssignableGroupMemberships();
-		MultipleGroupMembershipResponse GetAssignableGroupMembershipsByGroup(long groupId);
-		IndividualGroupMembershipResponse GetGroupMembershipsByMembershipId(long groupMembershipId);
-		IndividualGroupMembershipResponse GetGroupMembershipsByUserAndMembershipId(long userId, long groupMembershipId);
+        MultipleGroupMembershipResponse GetAssignableGroupMembershipsByGroup(long groupId);
+        IndividualGroupMembershipResponse GetGroupMembershipsByMembershipId(long groupMembershipId);
+        IndividualGroupMembershipResponse GetGroupMembershipsByUserAndMembershipId(long userId, long groupMembershipId);
 
-		/// <summary>
-		/// Creating a membership means assigning an agent to a given group
-		/// </summary>
-		/// <param name="groupMembership"></param>
-		/// <returns></returns>
-		IndividualGroupMembershipResponse CreateGroupMembership(GroupMembership groupMembership);
+        /// <summary>
+        /// Creating a membership means assigning an agent to a given group
+        /// </summary>
+        /// <param name="groupMembership"></param>
+        /// <returns></returns>
+        IndividualGroupMembershipResponse CreateGroupMembership(GroupMembership groupMembership);
 
-		MultipleGroupMembershipResponse SetGroupMembershipAsDefault(long userId, long groupMembershipId);
-		bool DeleteGroupMembership(long groupMembershipId);
-		bool DeleteUserGroupMembership(long userId, long groupMembershipId);
+        MultipleGroupMembershipResponse SetGroupMembershipAsDefault(long userId, long groupMembershipId);
+        bool DeleteGroupMembership(long groupMembershipId);
+        bool DeleteUserGroupMembership(long userId, long groupMembershipId);
 #endif
 
 #if ASYNC
-		Task<MultipleGroupResponse> GetGroupsAsync(int? perPage = null, int? page = null);
-		Task<MultipleGroupResponse> GetAssignableGroupsAsync();
-		Task<IndividualGroupResponse> GetGroupByIdAsync(long id);
-		Task<IndividualGroupResponse> CreateGroupAsync(string groupName);
-		Task<IndividualGroupResponse> UpdateGroupAsync(Group group);
-		Task<bool> DeleteGroupAsync(long id);
-		Task<MultipleGroupMembershipResponse> GetGroupMembershipsAsync();
-		Task<MultipleGroupMembershipResponse> GetGroupMembershipsByUserAsync(long userId);
-		Task<MultipleGroupMembershipResponse> GetGroupMembershipsByUserAsync(long userId, int perPage, int page);
-		Task<MultipleGroupMembershipResponse> GetGroupMembershipsByGroupAsync(long groupId);
+        Task<MultipleGroupResponse> GetGroupsAsync(int? perPage = null, int? page = null);
+        Task<MultipleGroupResponse> GetAssignableGroupsAsync();
+        Task<IndividualGroupResponse> GetGroupByIdAsync(long id);
+        Task<IndividualGroupResponse> CreateGroupAsync(string groupName);
+        Task<IndividualGroupResponse> UpdateGroupAsync(Group group);
+        Task<bool> DeleteGroupAsync(long id);
+        Task<MultipleGroupMembershipResponse> GetGroupMembershipsAsync();
+        Task<MultipleGroupMembershipResponse> GetGroupMembershipsByUserAsync(long userId);
+        Task<MultipleGroupMembershipResponse> GetGroupMembershipsByUserAsync(long userId, int perPage, int page);
+        Task<MultipleGroupMembershipResponse> GetGroupMembershipsByGroupAsync(long groupId);
         Task<MultipleGroupMembershipResponse> GetGroupMembershipsByGroupAsync(long groupId, int perPage, int page);
         Task<MultipleGroupMembershipResponse> GetAssignableGroupMembershipsAsync();
-		Task<MultipleGroupMembershipResponse> GetAssignableGroupMembershipsByGroupAsync(long groupId);
-		Task<IndividualGroupMembershipResponse> GetGroupMembershipsByMembershipIdAsync(long groupMembershipId);
-		Task<IndividualGroupMembershipResponse> GetGroupMembershipsByUserAndMembershipIdAsync(long userId, long groupMembershipId);
+        Task<MultipleGroupMembershipResponse> GetAssignableGroupMembershipsByGroupAsync(long groupId);
+        Task<IndividualGroupMembershipResponse> GetGroupMembershipsByMembershipIdAsync(long groupMembershipId);
+        Task<IndividualGroupMembershipResponse> GetGroupMembershipsByUserAndMembershipIdAsync(long userId, long groupMembershipId);
 
-		/// <summary>
-		/// Creating a membership means assigning an agent to a given group
-		/// </summary>
-		/// <param name="groupMembership"></param>
-		/// <returns></returns>
-		Task<IndividualGroupMembershipResponse> CreateGroupMembershipAsync(GroupMembership groupMembership);
+        /// <summary>
+        /// Creating a membership means assigning an agent to a given group
+        /// </summary>
+        /// <param name="groupMembership"></param>
+        /// <returns></returns>
+        Task<IndividualGroupMembershipResponse> CreateGroupMembershipAsync(GroupMembership groupMembership);
 
-		Task<MultipleGroupMembershipResponse> SetGroupMembershipAsDefaultAsync(long userId, long groupMembershipId);
-		Task<bool> DeleteGroupMembershipAsync(long groupMembershipId);
-		Task<bool> DeleteUserGroupMembershipAsync(long userId, long groupMembershipId);
+        Task<MultipleGroupMembershipResponse> SetGroupMembershipAsDefaultAsync(long userId, long groupMembershipId);
+        Task<bool> DeleteGroupMembershipAsync(long groupMembershipId);
+        Task<bool> DeleteUserGroupMembershipAsync(long userId, long groupMembershipId);
 #endif
-	}
+    }
 
-	public class Groups : Core, IGroups
-	{
+    public class Groups : Core, IGroups
+    {
         public Groups(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
             : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
         {

--- a/src/ZendeskApi_v2/Requests/Groups.cs
+++ b/src/ZendeskApi_v2/Requests/Groups.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Groups;
@@ -16,8 +16,10 @@ namespace ZendeskApi_v2.Requests
 		bool DeleteGroup(long id);
 		MultipleGroupMembershipResponse GetGroupMemberships();
 		MultipleGroupMembershipResponse GetGroupMembershipsByUser(long userId);
+		MultipleGroupMembershipResponse GetGroupMembershipsByUser(long userId, int perPage, int page);
 		MultipleGroupMembershipResponse GetGroupMembershipsByGroup(long groupId);
-		MultipleGroupMembershipResponse GetAssignableGroupMemberships();
+        MultipleGroupMembershipResponse GetGroupMembershipsByGroup(long groupId, int perPage, int page);
+        MultipleGroupMembershipResponse GetAssignableGroupMemberships();
 		MultipleGroupMembershipResponse GetAssignableGroupMembershipsByGroup(long groupId);
 		IndividualGroupMembershipResponse GetGroupMembershipsByMembershipId(long groupMembershipId);
 		IndividualGroupMembershipResponse GetGroupMembershipsByUserAndMembershipId(long userId, long groupMembershipId);
@@ -43,8 +45,10 @@ namespace ZendeskApi_v2.Requests
 		Task<bool> DeleteGroupAsync(long id);
 		Task<MultipleGroupMembershipResponse> GetGroupMembershipsAsync();
 		Task<MultipleGroupMembershipResponse> GetGroupMembershipsByUserAsync(long userId);
+		Task<MultipleGroupMembershipResponse> GetGroupMembershipsByUserAsync(long userId, int perPage, int page);
 		Task<MultipleGroupMembershipResponse> GetGroupMembershipsByGroupAsync(long groupId);
-		Task<MultipleGroupMembershipResponse> GetAssignableGroupMembershipsAsync();
+        Task<MultipleGroupMembershipResponse> GetGroupMembershipsByGroupAsync(long groupId, int perPage, int page);
+        Task<MultipleGroupMembershipResponse> GetAssignableGroupMembershipsAsync();
 		Task<MultipleGroupMembershipResponse> GetAssignableGroupMembershipsByGroupAsync(long groupId);
 		Task<IndividualGroupMembershipResponse> GetGroupMembershipsByMembershipIdAsync(long groupMembershipId);
 		Task<IndividualGroupMembershipResponse> GetGroupMembershipsByUserAndMembershipIdAsync(long userId, long groupMembershipId);
@@ -96,9 +100,9 @@ namespace ZendeskApi_v2.Requests
             var body = new { group };
             return GenericPut<IndividualGroupResponse>($"groups/{group.Id}.json", body);
         }
-        
+
         public bool DeleteGroup(long id)
-        {            
+        {
             return GenericDelete($"groups/{id}.json");
         }
 
@@ -114,9 +118,20 @@ namespace ZendeskApi_v2.Requests
             return GenericGet<MultipleGroupMembershipResponse>($"users/{userId}/group_memberships.json");
         }
 
+        public MultipleGroupMembershipResponse GetGroupMembershipsByUser(long userId, int perPage, int page)
+        {
+            return GenericPagedGet<MultipleGroupMembershipResponse>($"users/{userId}/group_memberships.json", perPage, page);
+        }
+
         public MultipleGroupMembershipResponse GetGroupMembershipsByGroup(long groupId)
         {
             return GenericGet<MultipleGroupMembershipResponse>($"groups/{groupId}/memberships.json");
+        }
+
+        public MultipleGroupMembershipResponse GetGroupMembershipsByGroup(long groupId, int perPage, int page)
+        {
+            return GenericPagedGet<MultipleGroupMembershipResponse>($"groups/{groupId}/memberships.json", perPage,
+                page);
         }
 
         public MultipleGroupMembershipResponse GetAssignableGroupMemberships()
@@ -156,7 +171,7 @@ namespace ZendeskApi_v2.Requests
         }
 
         public bool DeleteGroupMembership(long groupMembershipId)
-        {            
+        {
             return GenericDelete($"group_memberships/{groupMembershipId}.json");
         }
 
@@ -209,9 +224,21 @@ namespace ZendeskApi_v2.Requests
             return await GenericGetAsync<MultipleGroupMembershipResponse>($"users/{userId}/group_memberships.json");
         }
 
+        public async Task<MultipleGroupMembershipResponse> GetGroupMembershipsByUserAsync(long userId, int perPage, int page)
+        {
+            return await GenericPagedGetAsync<MultipleGroupMembershipResponse>($"users/{userId}/group_memberships.json", perPage,
+                page);
+        }
+
         public async Task<MultipleGroupMembershipResponse> GetGroupMembershipsByGroupAsync(long groupId)
         {
             return await GenericGetAsync<MultipleGroupMembershipResponse>($"groups/{groupId}/memberships.json");
+        }
+
+        public async Task<MultipleGroupMembershipResponse> GetGroupMembershipsByGroupAsync(long groupId, int perPage, int page)
+        {
+            return await GenericPagedGetAsync<MultipleGroupMembershipResponse>($"groups/{groupId}/memberships.json", perPage,
+                page);
         }
 
         public async Task<MultipleGroupMembershipResponse> GetAssignableGroupMembershipsAsync()

--- a/test/ZendeskApi_v2.Test/GroupTests.cs
+++ b/test/ZendeskApi_v2.Test/GroupTests.cs
@@ -1,11 +1,10 @@
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using ZendeskApi_v2;
 using ZendeskApi_v2.Models.Constants;
-using ZendeskApi_v2.Models.Users;
 using ZendeskApi_v2.Models.Groups;
-using System.Threading.Tasks;
-using ZendeskApi_v2.Models.Search;
+using ZendeskApi_v2.Models.Users;
 
 namespace Tests
 {
@@ -65,14 +64,27 @@ namespace Tests
         public void CanGetGroupMemberships()
         {
             var res = api.Groups.GetGroupMemberships();
-            Assert.Greater(res.Count, 0);
+            Assert.That(res.Count, Is.GreaterThan(0));
 
             var res1 = api.Groups.GetGroupMembershipsByUser(Settings.UserId);
-            Assert.Greater(res1.Count, 0);
+            Assert.That(res1.Count, Is.GreaterThan(0));
 
             var groups = api.Groups.GetGroups();
             var res2 = api.Groups.GetGroupMembershipsByGroup(groups.Groups[0].Id.Value);
-            Assert.Greater(res2.Count, 0);
+            Assert.That(res2.Count, Is.GreaterThan(0));
+
+            int count = 2;
+            int page = 2;
+
+            // Verify that first entry on page 2 is the same as 3rd entry on non-paginated request.
+            var res1Paged = api.Groups.GetGroupMembershipsByUser(Settings.UserId, count, page);
+            Assert.That(res1Paged.Count, Is.GreaterThan(0));
+            Assert.That(res1Paged.GroupMemberships[0].Id, Is.EqualTo(res1.GroupMemberships[2].Id));
+
+            // Verify that first entry on page 2 is the same as 3rd entry on non-paginated request.
+            var res2Paged = api.Groups.GetGroupMembershipsByGroup(groups.Groups[0].Id.Value, count, page);
+            Assert.That(res2Paged.Count, Is.GreaterThan(0));
+            Assert.That(res2Paged.GroupMemberships[0].Id, Is.EqualTo(res2.GroupMemberships[2].Id));
         }
 
         [Test]
@@ -123,6 +135,33 @@ namespace Tests
             Assert.True(api.Groups.DeleteGroupMembership(res.GroupMembership.Id.Value));
             Assert.True(api.Users.DeleteUser(user.Id.Value));
             Assert.True(api.Groups.DeleteGroup(group.Id.Value));
+        }
+
+        [Test]
+        public void CanGetGroupMembershipsAsync()
+        {
+            var res = api.Groups.GetGroupMembershipsAsync().Result;
+            Assert.That(res.Count, Is.GreaterThan(0));
+
+            var res1 = api.Groups.GetGroupMembershipsByUserAsync(Settings.UserId).Result;
+            Assert.That(res1.Count, Is.GreaterThan(0));
+
+            var groups = api.Groups.GetGroupsAsync().Result;
+            var res2 = api.Groups.GetGroupMembershipsByGroupAsync(groups.Groups[0].Id.Value).Result;
+            Assert.That(res2.Count, Is.GreaterThan(0));
+
+            int count = 2;
+            int page = 2;
+
+            // Verify that first entry on page 2 is the same as 3rd entry on non-paginated request.
+            var res1Paged = api.Groups.GetGroupMembershipsByUserAsync(Settings.UserId, count, page).Result;
+            Assert.That(res1Paged.Count, Is.GreaterThan(0));
+            Assert.That(res1Paged.GroupMemberships[0].Id, Is.EqualTo(res1.GroupMemberships[2].Id));
+
+            // Verify that first entry on page 2 is the same as 3rd entry on non-paginated request.
+            var res2Paged = api.Groups.GetGroupMembershipsByGroupAsync(groups.Groups[0].Id.Value, count, page).Result;
+            Assert.That(res2Paged.Count, Is.GreaterThan(0));
+            Assert.That(res2Paged.GroupMemberships[0].Id, Is.EqualTo(res2.GroupMemberships[2].Id));
         }
     }
 }


### PR DESCRIPTION
Currently `GetGroupMembershipsByGroup` only returns 100 results, so I added an overload to get paginated results. I also added a paginated overload for `GetGroupMembershipsByUser` just in case and I added unit tests for the new methods.