### PR TITLE
Extend Request model to accept email ccs

### DIFF
--- a/src/ZendeskApi_v2/Models/Requests/EmailCC.cs
+++ b/src/ZendeskApi_v2/Models/Requests/EmailCC.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace ZendeskApi_v2.Models.Tickets
+{
+    public class EmailCC
+    {
+        [JsonProperty("user_id")]
+        public string UserId { get; set; }
+
+        [JsonProperty("user_email")]
+        public string UserEmail { get; set; }
+
+        [JsonProperty("user_name")]
+        public string UserName { get; set; }
+    }
+}

--- a/src/ZendeskApi_v2/Models/Requests/Request.cs
+++ b/src/ZendeskApi_v2/Models/Requests/Request.cs
@@ -114,5 +114,8 @@ namespace ZendeskApi_v2.Models.Requests
 
         [JsonProperty("tags")]
         public IList<string> Tags { get; set; }
+
+        [JsonProperty("email_ccs")]
+        public IList<EmailCC> EmailCCs { get; set; }
     }
 }


### PR DESCRIPTION
When submitting a Request, the Zendesk API gives the possibility to also add a list of email CCs for the resulting ticket. This functionality was missing and is now added.