### PR TITLE
Add Custom Header

### DIFF
--- a/src/ZendeskApi_v2/Core.cs
+++ b/src/ZendeskApi_v2/Core.cs
@@ -46,6 +46,9 @@ namespace ZendeskApi_v2
         protected string Password;
         protected string ZendeskUrl;
         protected string ApiToken;
+        protected string CustomHeaderName;
+        protected string CustomHeaderValue;
+
         private readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
@@ -63,7 +66,7 @@ namespace ZendeskApi_v2
         /// <param name="zendeskApiUrl"></param>
         /// <param name="p_OAuthToken"></param>
         public Core(string zendeskApiUrl, string p_OAuthToken) :
-            this(zendeskApiUrl, null, null, null, p_OAuthToken)
+            this(zendeskApiUrl, null, null, null, p_OAuthToken, null, null)
         {
         }
 
@@ -73,7 +76,7 @@ namespace ZendeskApi_v2
         /// <param name="zendeskApiUrl"></param>
         /// <param name="p_OAuthToken"></param>
         public Core(string zendeskApiUrl, string user, string password, string apiToken) :
-            this(zendeskApiUrl, user, password, apiToken, null)
+            this(zendeskApiUrl, user, password, apiToken, null, null, null)
         {
         }
 
@@ -84,7 +87,7 @@ namespace ZendeskApi_v2
         /// <param name="user"></param>
         /// <param name="password">LEAVE BLANK IF USING TOKEN</param>
         /// <param name="apiToken">Optional Param which is used if specified instead of the password</param>
-        public Core(string zendeskApiUrl, string user, string password, string apiToken, string p_OAuthToken)
+        public Core(string zendeskApiUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
         {
             User = user;
             Password = password;
@@ -96,6 +99,8 @@ namespace ZendeskApi_v2
             ZendeskUrl = zendeskApiUrl;
             ApiToken = apiToken;
             OAuthToken = p_OAuthToken;
+            CustomHeaderName = customHeaderName;
+            CustomHeaderValue = customHeaderValue;
         }
 
 #if SYNC
@@ -134,6 +139,9 @@ namespace ZendeskApi_v2
 
                 req.Headers["Authorization"] = GetPasswordOrTokenAuthHeader();
                 req.PreAuthenticate = true;
+
+                if(CustomHeaderName.IsNotNullOrWhiteSpace() && CustomHeaderValue.IsNotNullOrWhiteSpace())
+                    req.Headers[CustomHeaderName] = CustomHeaderValue;
 
                 req.Method = requestMethod; //GET POST PUT DELETE
                 req.Accept = "application/json, application/xml, text/json, text/x-json, text/javascript, text/xml";
@@ -386,6 +394,9 @@ namespace ZendeskApi_v2
                 req.Headers["Authorization"] = GetPasswordOrTokenAuthHeader();
                 req.Method = requestMethod; //GET POST PUT DELETE
                 req.Accept = "application/json, application/xml, text/json, text/x-json, text/javascript, text/xml";
+
+                if (CustomHeaderName.IsNotNullOrWhiteSpace() && CustomHeaderValue.IsNotNullOrWhiteSpace())
+                    req.Headers[CustomHeaderName] = CustomHeaderValue;
 
                 byte[] data = null;
 

--- a/src/ZendeskApi_v2/Core.cs
+++ b/src/ZendeskApi_v2/Core.cs
@@ -46,8 +46,7 @@ namespace ZendeskApi_v2
         protected string Password;
         protected string ZendeskUrl;
         protected string ApiToken;
-        protected string CustomHeaderName;
-        protected string CustomHeaderValue;
+        protected Dictionary<string, string> CustomHeaders;
 
         private readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings
         {
@@ -66,7 +65,7 @@ namespace ZendeskApi_v2
         /// <param name="zendeskApiUrl"></param>
         /// <param name="p_OAuthToken"></param>
         public Core(string zendeskApiUrl, string p_OAuthToken) :
-            this(zendeskApiUrl, null, null, null, p_OAuthToken, null, null)
+            this(zendeskApiUrl, null, null, null, p_OAuthToken, null)
         {
         }
 
@@ -76,7 +75,7 @@ namespace ZendeskApi_v2
         /// <param name="zendeskApiUrl"></param>
         /// <param name="p_OAuthToken"></param>
         public Core(string zendeskApiUrl, string user, string password, string apiToken) :
-            this(zendeskApiUrl, user, password, apiToken, null, null, null)
+            this(zendeskApiUrl, user, password, apiToken, null, null)
         {
         }
 
@@ -87,7 +86,8 @@ namespace ZendeskApi_v2
         /// <param name="user"></param>
         /// <param name="password">LEAVE BLANK IF USING TOKEN</param>
         /// <param name="apiToken">Optional Param which is used if specified instead of the password</param>
-        public Core(string zendeskApiUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+        /// <param name="customHeaders">Optional Dictionary of custom headers that adds these headers to the request</param>
+        public Core(string zendeskApiUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
         {
             User = user;
             Password = password;
@@ -99,8 +99,7 @@ namespace ZendeskApi_v2
             ZendeskUrl = zendeskApiUrl;
             ApiToken = apiToken;
             OAuthToken = p_OAuthToken;
-            CustomHeaderName = customHeaderName;
-            CustomHeaderValue = customHeaderValue;
+            CustomHeaders = customHeaders;
         }
 
 #if SYNC
@@ -139,9 +138,7 @@ namespace ZendeskApi_v2
 
                 req.Headers["Authorization"] = GetPasswordOrTokenAuthHeader();
                 req.PreAuthenticate = true;
-
-                if(CustomHeaderName.IsNotNullOrWhiteSpace() && CustomHeaderValue.IsNotNullOrWhiteSpace())
-                    req.Headers[CustomHeaderName] = CustomHeaderValue;
+                AddCustomHeaders(req);
 
                 req.Method = requestMethod; //GET POST PUT DELETE
                 req.Accept = "application/json, application/xml, text/json, text/x-json, text/javascript, text/xml";
@@ -394,9 +391,7 @@ namespace ZendeskApi_v2
                 req.Headers["Authorization"] = GetPasswordOrTokenAuthHeader();
                 req.Method = requestMethod; //GET POST PUT DELETE
                 req.Accept = "application/json, application/xml, text/json, text/x-json, text/javascript, text/xml";
-
-                if (CustomHeaderName.IsNotNullOrWhiteSpace() && CustomHeaderValue.IsNotNullOrWhiteSpace())
-                    req.Headers[CustomHeaderName] = CustomHeaderValue;
+                AddCustomHeaders(req);
 
                 byte[] data = null;
 
@@ -630,6 +625,22 @@ namespace ZendeskApi_v2
             wException.Data.Add("jsonException", error);
 
             return wException;
+        }
+
+        /// <summary>
+        /// If the CustomHeaders Dictionary contains records then add them to the headers
+        /// of the passed in request
+        /// </summary>
+        /// <param name="request"></param>
+        private void AddCustomHeaders(HttpWebRequest request)
+        {
+            if (CustomHeaders != null)
+            {
+                foreach (var key in CustomHeaders.Keys)
+                {
+                    request.Headers.Add(key, CustomHeaders[key]);
+                }
+            }
         }
     }
 }

--- a/src/ZendeskApi_v2/Extensions/StringExtensions.cs
+++ b/src/ZendeskApi_v2/Extensions/StringExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace ZendeskApi_v2.Extensions
+﻿using ZendeskApi_v2.Models.Shared;
+
+namespace ZendeskApi_v2.Extensions
 {
     internal static class StringExtensions
     {
@@ -22,5 +24,7 @@
 
             return true;
         }
+
+        internal static bool IsNotNullOrWhiteSpace(this string value) => !IsNullOrWhiteSpace(value);
     }
 }

--- a/src/ZendeskApi_v2/HelpCenterApi.cs
+++ b/src/ZendeskApi_v2/HelpCenterApi.cs
@@ -1,4 +1,5 @@
-﻿using ZendeskApi_v2.Requests.HelpCenter;
+﻿using System.Collections.Generic;
+using ZendeskApi_v2.Requests.HelpCenter;
 
 namespace ZendeskApi_v2.HelpCenter
 {
@@ -26,20 +27,19 @@ namespace ZendeskApi_v2.HelpCenter
             string apiToken,
             string locale,
             string p_OAuthToken,
-            string customHeaderName,
-            string customHeaderValue)
+            Dictionary<string, string> customHeaders)
         {
-            Categories = new Categories(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
-            Sections = new Sections(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
-            Articles = new Articles(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
-            Translations = new Translations(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Votes = new Votes(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Comments = new Comments(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            UserSegments = new UserSegments(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Topics = new Topics(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Posts = new Posts(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Categories = new Categories(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
+            Sections = new Sections(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
+            Articles = new Articles(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
+            Translations = new Translations(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Votes = new Votes(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Comments = new Comments(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            UserSegments = new UserSegments(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Topics = new Topics(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Posts = new Posts(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders);
             Locale = locale;
-            ArticleAttachments = new ArticleAttachments(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
+            ArticleAttachments = new ArticleAttachments(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
         }
 
         public ICategories Categories { get; }

--- a/src/ZendeskApi_v2/HelpCenterApi.cs
+++ b/src/ZendeskApi_v2/HelpCenterApi.cs
@@ -25,19 +25,21 @@ namespace ZendeskApi_v2.HelpCenter
             string password,
             string apiToken,
             string locale,
-            string p_OAuthToken)
+            string p_OAuthToken,
+            string customHeaderName,
+            string customHeaderValue)
         {
-            Categories = new Categories(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken);
-            Sections = new Sections(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken);
-            Articles = new Articles(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken);
-            Translations = new Translations(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
-            Votes = new Votes(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
-            Comments = new Comments(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
-            UserSegments = new UserSegments(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
-            Topics = new Topics(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
-            Posts = new Posts(yourZendeskUrl, user, password, apiToken, p_OAuthToken);
+            Categories = new Categories(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
+            Sections = new Sections(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
+            Articles = new Articles(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
+            Translations = new Translations(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Votes = new Votes(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Comments = new Comments(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            UserSegments = new UserSegments(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Topics = new Topics(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Posts = new Posts(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
             Locale = locale;
-            ArticleAttachments = new ArticleAttachments(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken);
+            ArticleAttachments = new ArticleAttachments(yourZendeskUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
         }
 
         public ICategories Categories { get; }

--- a/src/ZendeskApi_v2/Requests/AccountsAndActivity.cs
+++ b/src/ZendeskApi_v2/Requests/AccountsAndActivity.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.AccountsAndActivities;
@@ -23,8 +23,8 @@ namespace ZendeskApi_v2.Requests
 	public class AccountsAndActivity : Core, IAccountsAndActivity
 	{
 
-        public AccountsAndActivity(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public AccountsAndActivity(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 #if SYNC

--- a/src/ZendeskApi_v2/Requests/AccountsAndActivity.cs
+++ b/src/ZendeskApi_v2/Requests/AccountsAndActivity.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.AccountsAndActivities;
@@ -15,16 +16,16 @@ namespace ZendeskApi_v2.Requests
 
 #if ASYNC
 		Task<SettingsResponse> GetSettingsAsync();
-		Task<GroupActivityResponse> GetActivitiesAync();
-		Task<IndividualActivityResponse> GetActivityByIdAync(long activityId);
+		Task<GroupActivityResponse> GetActivitiesAsync();
+		Task<IndividualActivityResponse> GetActivityByIdAsync(long activityId);
 #endif
 	}
 
 	public class AccountsAndActivity : Core, IAccountsAndActivity
 	{
 
-        public AccountsAndActivity(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public AccountsAndActivity(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 #if SYNC
@@ -49,12 +50,12 @@ namespace ZendeskApi_v2.Requests
         {
             return await GenericGetAsync<SettingsResponse>("account/settings.json");
         }        
-        public async Task<GroupActivityResponse> GetActivitiesAync()
+        public async Task<GroupActivityResponse> GetActivitiesAsync()
         {
             return await GenericGetAsync<GroupActivityResponse>("activities.json");
         }
 
-        public async Task<IndividualActivityResponse> GetActivityByIdAync(long activityId)
+        public async Task<IndividualActivityResponse> GetActivityByIdAsync(long activityId)
         {
             return await GenericGetAsync<IndividualActivityResponse>($"activities/{activityId}.json");
         }

--- a/src/ZendeskApi_v2/Requests/Attachments.cs
+++ b/src/ZendeskApi_v2/Requests/Attachments.cs
@@ -45,8 +45,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Attachments : Core, IAttachments
     {
-        public Attachments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Attachments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         { }
 #if SYNC
 

--- a/src/ZendeskApi_v2/Requests/Attachments.cs
+++ b/src/ZendeskApi_v2/Requests/Attachments.cs
@@ -45,8 +45,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Attachments : Core, IAttachments
     {
-        public Attachments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Attachments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         { }
 #if SYNC
 

--- a/src/ZendeskApi_v2/Requests/Automations.cs
+++ b/src/ZendeskApi_v2/Requests/Automations.cs
@@ -35,8 +35,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Automations : Core, IAutomations
     {
-        public Automations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Automations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Automations.cs
+++ b/src/ZendeskApi_v2/Requests/Automations.cs
@@ -35,8 +35,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Automations : Core, IAutomations
     {
-        public Automations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Automations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Brands.cs
+++ b/src/ZendeskApi_v2/Requests/Brands.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using System.Collections.Generic;
@@ -28,8 +28,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Brands : Core, IBrands
     {
-        public Brands(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Brands(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Brands.cs
+++ b/src/ZendeskApi_v2/Requests/Brands.cs
@@ -28,8 +28,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Brands : Core, IBrands
     {
-        public Brands(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Brands(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/CustomAgentRoles.cs
+++ b/src/ZendeskApi_v2/Requests/CustomAgentRoles.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.CustomRoles;
@@ -18,8 +19,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class CustomAgentRoles : Core, ICustomAgentRoles
 	{
-        public CustomAgentRoles(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public CustomAgentRoles(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/CustomAgentRoles.cs
+++ b/src/ZendeskApi_v2/Requests/CustomAgentRoles.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.CustomRoles;
@@ -18,8 +18,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class CustomAgentRoles : Core, ICustomAgentRoles
 	{
-        public CustomAgentRoles(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public CustomAgentRoles(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Groups.cs
+++ b/src/ZendeskApi_v2/Requests/Groups.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Groups;
@@ -68,8 +69,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Groups : Core, IGroups
     {
-        public Groups(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Groups(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Groups.cs
+++ b/src/ZendeskApi_v2/Requests/Groups.cs
@@ -68,8 +68,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Groups : Core, IGroups
     {
-        public Groups(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Groups(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/ArticleAttachments.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/ArticleAttachments.cs
@@ -39,9 +39,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
             string apiToken,
             string locale,
             string p_OAuthToken,
-            string customHeaderName,
-            string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+            Dictionary<string, string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
             _locale = locale;
         }

--- a/src/ZendeskApi_v2/Requests/HelpCenter/ArticleAttachments.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/ArticleAttachments.cs
@@ -38,8 +38,10 @@ namespace ZendeskApi_v2.Requests.HelpCenter
             string password,
             string apiToken,
             string locale,
-            string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+            string p_OAuthToken,
+            string customHeaderName,
+            string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
             _locale = locale;
         }

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
@@ -93,8 +93,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     {
         private readonly string urlPrefix = "help_center";
 
-        public Articles(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Articles(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
             if (!locale.IsNullOrWhiteSpace())
             {

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Articles.cs
@@ -93,8 +93,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     {
         private readonly string urlPrefix = "help_center";
 
-        public Articles(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Articles(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
             if (!locale.IsNullOrWhiteSpace())
             {

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
@@ -36,8 +36,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
             ? "help_center/categories"
             : $"help_center/{Locale}/categories";
 
-        public Categories(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Categories(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
             Locale = locale;
         }

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Categories.cs
@@ -1,5 +1,7 @@
 ﻿
 using ZendeskApi_v2.Models.HelpCenter.Categories;
+using System.Collections.Generic;
+
 #if ASYNC
 using System.Threading.Tasks;
 #endif
@@ -36,8 +38,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
             ? "help_center/categories"
             : $"help_center/{Locale}/categories";
 
-        public Categories(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Categories(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
             Locale = locale;
         }

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Comments.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Comments.cs
@@ -40,8 +40,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     /// </summary>
 	public class Comments : Core, IComments
 	{
-		public Comments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+		public Comments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
 		{
 		}
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Comments.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Comments.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.HelpCenter.Comments;
@@ -40,8 +41,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
     /// </summary>
 	public class Comments : Core, IComments
 	{
-		public Comments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+		public Comments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
 		{
 		}
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Posts.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Posts.cs
@@ -38,8 +38,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
     public class Posts : Core, IPosts
     {
-        public Posts(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Posts(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 #if SYNC

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Posts.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Posts.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.HelpCenter.Post;
@@ -38,8 +39,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
     public class Posts : Core, IPosts
     {
-        public Posts(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Posts(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 #if SYNC

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ZendeskApi_v2.Models.HelpCenter.Subscriptions;
 #endif
@@ -42,8 +43,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         private readonly string _locale;
         private readonly string _generalSectionsPath;
 
-        public Sections(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Sections(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
             _locale = locale;
             _generalSectionsPath = string.IsNullOrWhiteSpace(_locale) ? "help_center/sections" : $"help_center/{_locale}/sections";

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Sections.cs
@@ -42,8 +42,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
         private readonly string _locale;
         private readonly string _generalSectionsPath;
 
-        public Sections(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Sections(string yourZendeskUrl, string user, string password, string apiToken, string locale, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
             _locale = locale;
             _generalSectionsPath = string.IsNullOrWhiteSpace(_locale) ? "help_center/sections" : $"help_center/{_locale}/sections";

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Topics.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Topics.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ZendeskApi_v2.Models.HelpCenter.Subscriptions;
 #endif
@@ -36,8 +37,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
     public class Topics : Core, ITopics
     {
-        public Topics(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Topics(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 #if SYNC

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Topics.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Topics.cs
@@ -36,8 +36,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
     public class Topics : Core, ITopics
     {
-        public Topics(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Topics(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 #if SYNC

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
@@ -66,8 +66,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
 	public class Translations : Core, ITranslations
 	{
-		public Translations( string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken )
-			: base( yourZendeskUrl, user, password, apiToken, p_OAuthToken )
+		public Translations( string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+			: base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
 		{
 		}
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Translations.cs
@@ -66,8 +66,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
 	public class Translations : Core, ITranslations
 	{
-		public Translations( string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-			: base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+		public Translations( string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+			: base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
 		{
 		}
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/UserSegments.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/UserSegments.cs
@@ -56,8 +56,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
     public class UserSegments : Core, IUserSegments
     {
-        public UserSegments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public UserSegments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/UserSegments.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/UserSegments.cs
@@ -56,8 +56,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
     public class UserSegments : Core, IUserSegments
     {
-        public UserSegments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public UserSegments(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Votes.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Votes.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+
 #if ASYNC
 using System.Threading.Tasks;
 #endif
@@ -21,8 +23,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
 	public class Votes : Core, IVotes
 	{
-		public Votes(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+		public Votes(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
 		{
 		}
 

--- a/src/ZendeskApi_v2/Requests/HelpCenter/Votes.cs
+++ b/src/ZendeskApi_v2/Requests/HelpCenter/Votes.cs
@@ -21,8 +21,8 @@ namespace ZendeskApi_v2.Requests.HelpCenter
 
 	public class Votes : Core, IVotes
 	{
-		public Votes(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+		public Votes(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
 		{
 		}
 

--- a/src/ZendeskApi_v2/Requests/JobStatuses.cs
+++ b/src/ZendeskApi_v2/Requests/JobStatuses.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Shared;
@@ -19,8 +20,8 @@ namespace ZendeskApi_v2.Requests
 	public class JobStatuses : Core, IJobStatuses
 	{
 
-        public JobStatuses(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public JobStatuses(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/JobStatuses.cs
+++ b/src/ZendeskApi_v2/Requests/JobStatuses.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Shared;
@@ -19,8 +19,8 @@ namespace ZendeskApi_v2.Requests
 	public class JobStatuses : Core, IJobStatuses
 	{
 
-        public JobStatuses(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public JobStatuses(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Locales.cs
+++ b/src/ZendeskApi_v2/Requests/Locales.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Locales;
@@ -63,8 +64,8 @@ namespace ZendeskApi_v2.Requests
     public class Locales : Core, ILocales
     {
 
-        public Locales(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Locales(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Locales.cs
+++ b/src/ZendeskApi_v2/Requests/Locales.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Locales;
@@ -63,8 +63,8 @@ namespace ZendeskApi_v2.Requests
     public class Locales : Core, ILocales
     {
 
-        public Locales(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Locales(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Macros.cs
+++ b/src/ZendeskApi_v2/Requests/Macros.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Macros;
@@ -80,8 +80,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class Macros : Core, IMacros
 	{
-        public Macros(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Macros(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Macros.cs
+++ b/src/ZendeskApi_v2/Requests/Macros.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Macros;
@@ -80,8 +81,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class Macros : Core, IMacros
 	{
-        public Macros(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Macros(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Organizations.cs
+++ b/src/ZendeskApi_v2/Requests/Organizations.cs
@@ -111,8 +111,8 @@ namespace ZendeskApi_v2.Requests
     {
         private const string _incremental_export = "incremental/organizations.json?start_time=";
 
-        public Organizations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Organizations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Organizations.cs
+++ b/src/ZendeskApi_v2/Requests/Organizations.cs
@@ -111,8 +111,8 @@ namespace ZendeskApi_v2.Requests
     {
         private const string _incremental_export = "incremental/organizations.json?start_time=";
 
-        public Organizations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Organizations(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Requests.cs
+++ b/src/ZendeskApi_v2/Requests/Requests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+
 #if ASYNC
 using System.Threading.Tasks;
 #endif
@@ -111,8 +113,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Requests : Core, IRequests
     {
-        public Requests(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Requests(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Requests.cs
+++ b/src/ZendeskApi_v2/Requests/Requests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 #if ASYNC
 using System.Threading.Tasks;
 #endif
@@ -111,8 +111,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Requests : Core, IRequests
     {
-        public Requests(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Requests(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/SatisfactionRatings.cs
+++ b/src/ZendeskApi_v2/Requests/SatisfactionRatings.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Satisfaction;
@@ -42,8 +43,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class SatisfactionRatings : Core, ISatisfactionRatings
 	{
-        public SatisfactionRatings(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public SatisfactionRatings(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/SatisfactionRatings.cs
+++ b/src/ZendeskApi_v2/Requests/SatisfactionRatings.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.Satisfaction;
@@ -42,8 +42,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class SatisfactionRatings : Core, ISatisfactionRatings
 	{
-        public SatisfactionRatings(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public SatisfactionRatings(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Schedules.cs
+++ b/src/ZendeskApi_v2/Requests/Schedules.cs
@@ -39,8 +39,8 @@ namespace ZendeskApi_v2.Requests
     }
     public class Schedules : Core, ISchedules
     {
-        public Schedules(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Schedules(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Schedules.cs
+++ b/src/ZendeskApi_v2/Requests/Schedules.cs
@@ -39,8 +39,8 @@ namespace ZendeskApi_v2.Requests
     }
     public class Schedules : Core, ISchedules
     {
-        public Schedules(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Schedules(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Search.cs
+++ b/src/ZendeskApi_v2/Requests/Search.cs
@@ -1,4 +1,4 @@
-
+﻿
 using System;
 using System.Linq;
 using ZendeskApi_v2.Models;
@@ -106,8 +106,8 @@ namespace ZendeskApi_v2.Requests
     /// </summary>
     public class Search : Core, ISearch
     {
-        public Search(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Search(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Search.cs
+++ b/src/ZendeskApi_v2/Requests/Search.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using ZendeskApi_v2.Models.Search;
 using ZendeskApi_v2.Models.Tickets;
 using ZendeskApi_v2.Models.Users;
+using System.Collections.Generic;
 
 namespace ZendeskApi_v2.Requests
 {
@@ -106,8 +107,8 @@ namespace ZendeskApi_v2.Requests
     /// </summary>
     public class Search : Core, ISearch
     {
-        public Search(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Search(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/SharingAgreements.cs
+++ b/src/ZendeskApi_v2/Requests/SharingAgreements.cs
@@ -1,4 +1,5 @@
 ﻿#if ASYNC
+using System.Collections.Generic;
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.SharingAgreements;
@@ -19,8 +20,8 @@ namespace ZendeskApi_v2.Requests
 	public class SharingAgreements : Core, ISharingAgreements
 	{
 
-        public SharingAgreements(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public SharingAgreements(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/SharingAgreements.cs
+++ b/src/ZendeskApi_v2/Requests/SharingAgreements.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using ZendeskApi_v2.Models.SharingAgreements;
@@ -19,8 +19,8 @@ namespace ZendeskApi_v2.Requests
 	public class SharingAgreements : Core, ISharingAgreements
 	{
 
-        public SharingAgreements(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public SharingAgreements(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Tags.cs
+++ b/src/ZendeskApi_v2/Requests/Tags.cs
@@ -33,8 +33,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class Tags : Core, ITags
 	{
-        public Tags(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Tags(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Tags.cs
+++ b/src/ZendeskApi_v2/Requests/Tags.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 #if ASYNC
 using System.Threading.Tasks;
 #endif
@@ -33,8 +33,8 @@ namespace ZendeskApi_v2.Requests
 
 	public class Tags : Core, ITags
 	{
-        public Tags(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Tags(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Targets.cs
+++ b/src/ZendeskApi_v2/Requests/Targets.cs
@@ -26,8 +26,8 @@ namespace ZendeskApi_v2.Requests
     }
     public class Targets : Core, ITargets
     {
-        public Targets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Targets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Targets.cs
+++ b/src/ZendeskApi_v2/Requests/Targets.cs
@@ -26,8 +26,8 @@ namespace ZendeskApi_v2.Requests
     }
     public class Targets : Core, ITargets
     {
-        public Targets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Targets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Tickets.cs
+++ b/src/ZendeskApi_v2/Requests/Tickets.cs
@@ -291,8 +291,8 @@ namespace ZendeskApi_v2.Requests
         private const string _ticket_metrics = "ticket_metrics";
         private const string _incremental_export = "incremental/tickets.json?start_time=";
 
-        public Tickets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Tickets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Tickets.cs
+++ b/src/ZendeskApi_v2/Requests/Tickets.cs
@@ -291,8 +291,8 @@ namespace ZendeskApi_v2.Requests
         private const string _ticket_metrics = "ticket_metrics";
         private const string _incremental_export = "incremental/tickets.json?start_time=";
 
-        public Tickets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Tickets(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Triggers.cs
+++ b/src/ZendeskApi_v2/Requests/Triggers.cs
@@ -31,8 +31,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Triggers : Core, ITriggers
     {
-        public Triggers(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Triggers(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Triggers.cs
+++ b/src/ZendeskApi_v2/Requests/Triggers.cs
@@ -1,4 +1,4 @@
-#if ASYNC
+﻿#if ASYNC
 using System.Threading.Tasks;
 #endif
 using System.Collections.Generic;
@@ -31,8 +31,8 @@ namespace ZendeskApi_v2.Requests
 
     public class Triggers : Core, ITriggers
     {
-        public Triggers(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Triggers(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Users.cs
+++ b/src/ZendeskApi_v2/Requests/Users.cs
@@ -214,8 +214,8 @@ namespace ZendeskApi_v2.Requests
     {
         private const string _incremental_export = "incremental/users.json?start_time=";
 
-        public Users(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Users(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Users.cs
+++ b/src/ZendeskApi_v2/Requests/Users.cs
@@ -214,8 +214,8 @@ namespace ZendeskApi_v2.Requests
     {
         private const string _incremental_export = "incremental/users.json?start_time=";
 
-        public Users(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Users(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Views.cs
+++ b/src/ZendeskApi_v2/Requests/Views.cs
@@ -38,8 +38,8 @@ namespace ZendeskApi_v2.Requests
 	public class Views : Core, IViews
 	{
         
-        public Views(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Views(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Views.cs
+++ b/src/ZendeskApi_v2/Requests/Views.cs
@@ -38,8 +38,8 @@ namespace ZendeskApi_v2.Requests
 	public class Views : Core, IViews
 	{
         
-        public Views(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Views(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Voice.cs
+++ b/src/ZendeskApi_v2/Requests/Voice.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 #if ASYNC
 using System.Threading.Tasks;
@@ -37,8 +38,8 @@ namespace ZendeskApi_v2.Requests
         private const string currentQueueActivity = "channels/voice/stats/current_queue_activity";
         private const string accountOverview = "channels/voice/stats/account_overview";
 
-        public Voice(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
+        public Voice(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, Dictionary<string,string> customHeaders)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaders)
         {
         }
 

--- a/src/ZendeskApi_v2/Requests/Voice.cs
+++ b/src/ZendeskApi_v2/Requests/Voice.cs
@@ -37,8 +37,8 @@ namespace ZendeskApi_v2.Requests
         private const string currentQueueActivity = "channels/voice/stats/current_queue_activity";
         private const string accountOverview = "channels/voice/stats/account_overview";
 
-        public Voice(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken)
-            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken)
+        public Voice(string yourZendeskUrl, string user, string password, string apiToken, string p_OAuthToken, string customHeaderName, string customHeaderValue)
+            : base(yourZendeskUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue)
         {
         }
 

--- a/src/ZendeskApi_v2/ZendeskApi.cs
+++ b/src/ZendeskApi_v2/ZendeskApi.cs
@@ -118,37 +118,58 @@ namespace ZendeskApi_v2
                           string password,
                           string apiToken,
                           string locale,
-                          string p_OAuthToken)
+                          string p_OAuthToken) : this(yourZendeskUrl,user,password, apiToken,locale, p_OAuthToken, null, null)
+        {
+           
+        }
+        /// <summary>
+        ///  Constructor that takes 8 params.
+        /// </summary>
+        /// <param name="yourZendeskUrl">Will be formatted to "https://yoursite.zendesk.com/api/v2"</param>
+        /// <param name="user">Email address of the user</param>
+        /// <param name="password">LEAVE BLANK IF USING TOKEN</param>
+        /// <param name="apiToken">Used if specified instead of the password</param>
+        /// <param name="locale">Locale to use for Help Center requests. Defaults to "en-us" if no value is provided.</param>
+        /// <param name="p_OAuthToken">Authentication token</param>
+        /// <param name="customHeaderName">The name of the custom header</param>
+        /// <param name="customHeaderValue">The value to store in the header</param>
+        public ZendeskApi(string yourZendeskUrl,
+                          string user,
+                          string password,
+                          string apiToken,
+                          string locale,
+                          string p_OAuthToken,
+                          string customHeaderName,
+                          string customHeaderValue)
         {
             var formattedUrl = GetFormattedZendeskUrl(yourZendeskUrl).AbsoluteUri;
 
-            Tickets = new Tickets(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Attachments = new Attachments(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Brands = new Brands(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Views = new Views(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Users = new Users(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Requests = new Requests.Requests(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Groups = new Groups(formattedUrl, user, password, apiToken, p_OAuthToken);
-            CustomAgentRoles = new CustomAgentRoles(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Organizations = new Organizations(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Search = new Search(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Tags = new Tags(formattedUrl, user, password, apiToken, p_OAuthToken);
-            AccountsAndActivity = new AccountsAndActivity(formattedUrl, user, password, apiToken, p_OAuthToken);
-            JobStatuses = new JobStatuses(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Locales = new Locales(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Macros = new Macros(formattedUrl, user, password, apiToken, p_OAuthToken);
-            SatisfactionRatings = new SatisfactionRatings(formattedUrl, user, password, apiToken, p_OAuthToken);
-            SharingAgreements = new SharingAgreements(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Triggers = new Triggers(formattedUrl, user, password, apiToken, p_OAuthToken);
-            HelpCenter = new HelpCenterApi(formattedUrl, user, password, apiToken, locale, p_OAuthToken);
-            Voice = new Voice(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Schedules = new Schedules(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Targets = new Targets(formattedUrl, user, password, apiToken, p_OAuthToken);
-            Automations = new Automations(formattedUrl, user, password, apiToken, p_OAuthToken);
+            Tickets = new Tickets(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Attachments = new Attachments(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Brands = new Brands(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Views = new Views(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Users = new Users(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Requests = new Requests.Requests(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Groups = new Groups(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            CustomAgentRoles = new CustomAgentRoles(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Organizations = new Organizations(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Search = new Search(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Tags = new Tags(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            AccountsAndActivity = new AccountsAndActivity(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            JobStatuses = new JobStatuses(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Locales = new Locales(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Macros = new Macros(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            SatisfactionRatings = new SatisfactionRatings(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            SharingAgreements = new SharingAgreements(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Triggers = new Triggers(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            HelpCenter = new HelpCenterApi(formattedUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
+            Voice = new Voice(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Schedules = new Schedules(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Targets = new Targets(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Automations = new Automations(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
 
             ZendeskUrl = formattedUrl;
         }
-
 #if SYNC
 
         /// <summary>

--- a/src/ZendeskApi_v2/ZendeskApi.cs
+++ b/src/ZendeskApi_v2/ZendeskApi.cs
@@ -2,6 +2,7 @@
 using ZendeskApi_v2.Requests;
 using System.Net;
 using ZendeskApi_v2.HelpCenter;
+using System.Collections.Generic;
 
 #if Net35
 using System.Web;
@@ -118,12 +119,12 @@ namespace ZendeskApi_v2
                           string password,
                           string apiToken,
                           string locale,
-                          string p_OAuthToken) : this(yourZendeskUrl,user,password, apiToken,locale, p_OAuthToken, null, null)
+                          string p_OAuthToken) : this(yourZendeskUrl,user,password, apiToken,locale, p_OAuthToken, null)
         {
         }
 
         /// <summary>
-        ///  Constructor that takes 8 params.
+        ///  Constructor that takes 7 params.
         /// </summary>
         /// <param name="yourZendeskUrl">Will be formatted to "https://yoursite.zendesk.com/api/v2"</param>
         /// <param name="user">Email address of the user</param>
@@ -139,34 +140,33 @@ namespace ZendeskApi_v2
                           string apiToken,
                           string locale,
                           string p_OAuthToken,
-                          string customHeaderName,
-                          string customHeaderValue)
+                          Dictionary<string, string> customHeaders)
         {
             var formattedUrl = GetFormattedZendeskUrl(yourZendeskUrl).AbsoluteUri;
 
-            Tickets = new Tickets(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Attachments = new Attachments(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Brands = new Brands(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Views = new Views(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Users = new Users(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Requests = new Requests.Requests(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Groups = new Groups(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            CustomAgentRoles = new CustomAgentRoles(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Organizations = new Organizations(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Search = new Search(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Tags = new Tags(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            AccountsAndActivity = new AccountsAndActivity(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            JobStatuses = new JobStatuses(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Locales = new Locales(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Macros = new Macros(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            SatisfactionRatings = new SatisfactionRatings(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            SharingAgreements = new SharingAgreements(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Triggers = new Triggers(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            HelpCenter = new HelpCenterApi(formattedUrl, user, password, apiToken, locale, p_OAuthToken, customHeaderName, customHeaderValue);
-            Voice = new Voice(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Schedules = new Schedules(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Targets = new Targets(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
-            Automations = new Automations(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaderName, customHeaderValue);
+            Tickets = new Tickets(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Attachments = new Attachments(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Brands = new Brands(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Views = new Views(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Users = new Users(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Requests = new Requests.Requests(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Groups = new Groups(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            CustomAgentRoles = new CustomAgentRoles(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Organizations = new Organizations(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Search = new Search(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Tags = new Tags(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            AccountsAndActivity = new AccountsAndActivity(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            JobStatuses = new JobStatuses(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Locales = new Locales(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Macros = new Macros(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            SatisfactionRatings = new SatisfactionRatings(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            SharingAgreements = new SharingAgreements(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Triggers = new Triggers(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            HelpCenter = new HelpCenterApi(formattedUrl, user, password, apiToken, locale, p_OAuthToken, customHeaders);
+            Voice = new Voice(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Schedules = new Schedules(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Targets = new Targets(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
+            Automations = new Automations(formattedUrl, user, password, apiToken, p_OAuthToken, customHeaders);
 
             ZendeskUrl = formattedUrl;
         }

--- a/src/ZendeskApi_v2/ZendeskApi.cs
+++ b/src/ZendeskApi_v2/ZendeskApi.cs
@@ -120,7 +120,6 @@ namespace ZendeskApi_v2
                           string locale,
                           string p_OAuthToken) : this(yourZendeskUrl,user,password, apiToken,locale, p_OAuthToken, null, null)
         {
-           
         }
 
         /// <summary>

--- a/src/ZendeskApi_v2/ZendeskApi.cs
+++ b/src/ZendeskApi_v2/ZendeskApi.cs
@@ -122,6 +122,7 @@ namespace ZendeskApi_v2
         {
            
         }
+
         /// <summary>
         ///  Constructor that takes 8 params.
         /// </summary>

--- a/tests/ZendeskApi_v2.Tests/RequestTests.cs
+++ b/tests/ZendeskApi_v2.Tests/RequestTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using ZendeskApi_v2.Models.Requests;
 using ZendeskApi_v2.Models.Tickets;
 using ZendeskApi_v2.Tests.Base;
@@ -159,6 +160,7 @@ public class RequestTests : TestBase
         };
 
         var res = Api.Requests.CreateRequest(req);
+        Thread.Sleep(500); // delay after create  or update
 
         try
         {
@@ -186,6 +188,8 @@ public class RequestTests : TestBase
                 Public = true
             };
             _ = Api.Requests.UpdateRequest(res1.Request);
+            Thread.Sleep(500); // delay after create  or update
+
             var res3 = Api.Requests.GetRequestCommentsById(res.Request.Id.Value);
 
             var comment = res3.Comments.OrderBy(c => c.CreatedAt).Last();

--- a/tests/ZendeskApi_v2.Tests/TicketTests.cs
+++ b/tests/ZendeskApi_v2.Tests/TicketTests.cs
@@ -1506,7 +1506,7 @@ public class TicketTests : TestBase
         Assert.That(newTicket.Via.Channel, Is.EqualTo("api"));
 
         var comment = new Comment { Body = secondCommentBody, Public = true };
-
+        await Task.Delay(1000);
         var resp2 = await Api.Tickets.UpdateTicketAsync(newTicket, comment);
         await Task.Delay(2000);
         var resp3 = await Api.Tickets.GetTicketCommentsAsync(newTicket.Id.Value);


### PR DESCRIPTION
We have a use case where we have a customisation on ZenDesk where a custom header is passed in and read and the site redirects to a client subsite based upon this header.

This means we need to customise the ZenDeskApi_V2 to support adding this custom header. 

The following PR adds a new extended constructor that allows passing in the name of the custom header, and the value. 
If provided it will add the Custom Header to the Request.  If not it works as it has previously.

It is an overloaded constructor so fully backwards compatible, as all existing constructors are retained.