### PR TITLE
Adding support for Locale to the User model #589

### DIFF
--- a/src/ZendeskApi_v2/Models/Users/User.cs
+++ b/src/ZendeskApi_v2/Models/Users/User.cs
@@ -25,6 +25,9 @@ namespace ZendeskApi_v2.Models.Users
         [JsonProperty("shared")]
         public bool? Shared { get; set; }
 
+        [JsonProperty("locale")]
+        public string Locale { get; set; }
+
         [JsonProperty("locale_id")]
         public long? LocaleId { get; set; }
 

--- a/tests/ZendeskApi_v2.Tests/UserTests.cs
+++ b/tests/ZendeskApi_v2.Tests/UserTests.cs
@@ -268,6 +268,7 @@ public class UserTests : TestBase
             Email = "test772@tester.com",
             Role = "end-user",
             Verified = true,
+            Locale = "en-US",
             CustomFields = new Dictionary<string, object>()
                               {
                                   {"user_dropdown", "option_1"}
@@ -291,6 +292,7 @@ public class UserTests : TestBase
             Name = "tester user72",
             Email = "test772@tester.com",
             Role = "end-user",
+            Locale = "en-US",
             Verified = true,
             CustomFields = new Dictionary<string, object>()
                               {


### PR DESCRIPTION
I am in need of being able to set Locale on the creation or update of a user in the Zendesk service. This PR updates the User model to support using the Locale property. I have added the property to the User object and updated two Unit Tests to include the property during the Create or Update User test.

Issue: #589